### PR TITLE
finally show in category name

### DIFF
--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -92,7 +92,7 @@ const getApprovedEventsPaginated = asyncHandler(async (req, res) => {
 });
 // Get all events (admin)
 const getAllEvents = asyncHandler(async (req, res) => {
-  const events = await Event.find();
+  const events = await Event.find().populate("category", "name");
   res.json(events);
 });
 
@@ -108,13 +108,17 @@ const approveEvent = asyncHandler(async (req, res) => {
   res.json({ message: "Event approved", event });
 });
 
-// Update event (user or admin)
+/**
+ * Update event (user or admin)
+ * Allows admin to set approved status, and populates category on response
+ */
 const updateEvent = asyncHandler(async (req, res) => {
-  const { title, description, category, location, time } = req.body;
+  const { title, description, category, location, time, approved } = req.body;
   let picture = null;
   if (req.file) {
     picture = `/uploads/${req.file.filename}`;
   }
+
   const event = await Event.findById(req.params.id);
   if (!event) {
     res.status(404);
@@ -134,9 +138,28 @@ const updateEvent = asyncHandler(async (req, res) => {
   if (location) event.location = location;
   if (time) event.time = time;
   if (picture) event.picture = picture;
+  // Allow admin to set approved status (accept boolean or string)
+  if (req.user.role === "admin" && typeof approved !== "undefined") {
+    // Accept boolean, "approved", "pending", "true", "false"
+    if (typeof approved === "boolean") {
+      event.approved = approved;
+    } else if (typeof approved === "string") {
+      if (approved === "approved" || approved === "true") {
+        event.approved = true;
+      } else if (approved === "pending" || approved === "false") {
+        event.approved = false;
+      }
+    } else {
+      // fallback: treat anything else as false
+      event.approved = false;
+    }
+  }
+
   // If user updates, event must be re-approved
   if (req.user.role !== "admin") event.approved = false;
   await event.save();
+  // Populate category with name for response
+  await event.populate("category", "name");
   res.json({ message: "Event updated", event });
 });
 

--- a/frontend/src/pages/admin/ManageEvents.jsx
+++ b/frontend/src/pages/admin/ManageEvents.jsx
@@ -38,7 +38,7 @@ const ManageEvents = () => {
       try {
         const user = JSON.parse(localStorage.getItem("user"));
         const response = await axios.get(
-          `${import.meta.env.VITE_BACKEND}api/categories`,
+          `${import.meta.env.VITE_BACKEND}api/event-categories`,
           {
             headers: { authorization: `Bearer ${user.token}` },
           }
@@ -96,7 +96,7 @@ const ManageEvents = () => {
   const handleSaveEdit = async (eventId) => {
     try {
       const user = JSON.parse(localStorage.getItem("user"));
-      // Robust conversion: handle both string and boolean
+      // Convert approved to boolean for backend
       let approvedValue;
       if (editEvent.approved === "approved" || editEvent.approved === true) {
         approvedValue = true;
@@ -106,9 +106,9 @@ const ManageEvents = () => {
       ) {
         approvedValue = false;
       } else {
-        approvedValue = null;
+        approvedValue = false; // default to false if unknown
       }
-      await axios.put(
+      const response = await axios.put(
         `${import.meta.env.VITE_BACKEND}api/events/${eventId}`,
         {
           title: editEvent.title,
@@ -122,18 +122,11 @@ const ManageEvents = () => {
         },
         { headers: { authorization: `Bearer ${user.token}` } }
       );
+      // Use backend response to update local state
       setEvents((prev) =>
         prev.map((e) =>
           e._id === eventId
-            ? {
-                ...e,
-                title: editEvent.title,
-                time: editEvent.time,
-                description: editEvent.description,
-                approved: approvedValue,
-                location: editEvent.location,
-                category: editEvent.category,
-              }
+            ? response.data.event // use the updated event from backend
             : e
         )
       );
@@ -373,7 +366,7 @@ const ManageEvents = () => {
                             onChange={(e) =>
                               setEditEvent((prev) => ({
                                 ...prev,
-                                approved: e.target.value,
+                                approved: e.target.value === "approved",
                               }))
                             }
                           >


### PR DESCRIPTION
This pull request introduces enhancements to both the backend and frontend of the event management system. Key changes include improvements to event approval handling, better integration between backend and frontend, and adjustments to API endpoints for consistency.

### Backend Changes:
* **Event Population Enhancements**:
  - Updated `getAllEvents` to populate the `category` field with its `name` for easier access in responses. (`backend/controllers/eventController.js`, [backend/controllers/eventController.jsL95-R95](diffhunk://#diff-5a52a2ebe7c3b87233565908a54380873065cecc2177a1fe1cd222a236d544e7L95-R95))
  - Modified `updateEvent` to populate the `category` field in the response after saving changes. (`backend/controllers/eventController.js`, [backend/controllers/eventController.jsR141-R162](diffhunk://#diff-5a52a2ebe7c3b87233565908a54380873065cecc2177a1fe1cd222a236d544e7R141-R162))

* **Approval Logic Updates**:
  - Enhanced `updateEvent` to allow admins to set the `approved` status using flexible inputs (boolean or specific strings like "approved", "true", etc.). Non-admin users automatically set the event to "not approved" upon updates. (`backend/controllers/eventController.js`, [backend/controllers/eventController.jsR141-R162](diffhunk://#diff-5a52a2ebe7c3b87233565908a54380873065cecc2177a1fe1cd222a236d544e7R141-R162))

### Frontend Changes:
* **API Endpoint Adjustment**:
  - Changed the endpoint for fetching event categories from `/api/categories` to `/api/event-categories` for consistency with backend naming conventions. (`frontend/src/pages/admin/ManageEvents.jsx`, [frontend/src/pages/admin/ManageEvents.jsxL41-R41](diffhunk://#diff-245999888f4929ac85c82ca1c556272cf3a3b3e3709d1d6126440d1ebf2420e7L41-R41))

* **Event Approval Handling**:
  - Refined the `approved` field handling in `ManageEvents` to ensure conversion to boolean values for backend compatibility. (`frontend/src/pages/admin/ManageEvents.jsx`, [[1]](diffhunk://#diff-245999888f4929ac85c82ca1c556272cf3a3b3e3709d1d6126440d1ebf2420e7L99-R99) [[2]](diffhunk://#diff-245999888f4929ac85c82ca1c556272cf3a3b3e3709d1d6126440d1ebf2420e7L376-R369)
  - Updated the local state with the backend response after saving edits to ensure data consistency. (`frontend/src/pages/admin/ManageEvents.jsx`, [frontend/src/pages/admin/ManageEvents.jsxR125-R129](diffhunk://#diff-245999888f4929ac85c82ca1c556272cf3a3b3e3709d1d6126440d1ebf2420e7R125-R129))